### PR TITLE
Fix Sink re-activation behaviour

### DIFF
--- a/Tests/CombineXTests/Subscribers/AssignSpec.swift
+++ b/Tests/CombineXTests/Subscribers/AssignSpec.swift
@@ -78,6 +78,27 @@ class AssignSpec: QuickSpec {
                 
                 expect(obj.records).to(equal([1]))
             }
+
+            // MARK: 1.4 should not receive vaules when re-activated
+            it("should not receive vaules when re-activated") {
+                let pub = PassthroughSubject<Int, Never>()
+
+                let obj = Object()
+                let assign = Subscribers.Assign<Object, Int>(object: obj, keyPath: \Object.value)
+                pub.subscribe(assign)
+                pub.send(1)
+                pub.send(completion: .finished)
+
+                expect(obj.records).to(equal([1]))
+
+                // Try to start a new one
+                let pub2 = PassthroughSubject<Int, Never>()
+                pub2.subscribe(assign)
+                pub2.send(2)
+                pub2.send(completion: .finished)
+
+                expect(obj.records).to(equal([1]))
+            }
         }
         
         // MARK: - Release Resources

--- a/Tests/CombineXTests/Subscribers/SinkSpec.swift
+++ b/Tests/CombineXTests/Subscribers/SinkSpec.swift
@@ -81,6 +81,29 @@ class SinkSpec: QuickSpec {
                 
                 _ = sink
             }
+
+            // MARK: 1.4 should not receive vaules when re-activated
+            it("should not receive vaules when re-activated") {
+                let pub = PassthroughSubject<Int, Never>()
+
+                var events = [TestSubscriberEvent<Int, Never>]()
+                let sink = Subscribers.Sink<Int, Never>(receiveCompletion: { (c) in
+                    events.append(.completion(c))
+                }, receiveValue: { v in
+                    events.append(.value(v))
+                })
+                pub.subscribe(sink)
+                pub.send(1)
+
+                expect(events).to(equal([.value(1)]))
+
+                // Try to start a new one
+                let pub2 = PassthroughSubject<Int, Never>()
+                pub2.subscribe(sink)
+                pub2.send(2)
+
+                expect(events).to(equal([.value(1)]))
+            }
         }
         
         // MARK: - Release Resources


### PR DESCRIPTION
I tested CombineX against the tests outlined in the blog post from @mattgallagher [here](https://www.cocoawithlove.com/blog/twenty-two-short-tests-of-combine-part-1.html). I found that the `Sink` is behaving incorrectly when re-activating it, i.e. switching it from one publisher to another. I also created tests for it and verified that `Assign` is working properly as well.