### PR TITLE
Fix threading issue for sending values on subjects

### DIFF
--- a/Sources/CXUtility/Atom.swift
+++ b/Sources/CXUtility/Atom.swift
@@ -2,6 +2,14 @@ public final class Atom<Val> {
     
     private let lock = Lock()
     private var val: Val
+
+    var isMutating: Bool {
+        if lock.try() {
+            lock.unlock()
+            return false
+        }
+        return true
+    }
     
     public init(val: Val) {
         self.val = val

--- a/Tests/CombineXTests/Subjects/PassthroughSubjectSpec.swift
+++ b/Tests/CombineXTests/Subjects/PassthroughSubjectSpec.swift
@@ -463,6 +463,43 @@ class PassthroughSubjectSpec: QuickSpec {
                 
                 expect(sub.events.count).to(equal(10))
             }
+
+            // MARK: 4.4 should not invoke receiveValue on multiple threads at the same time
+            it("no guarantee of synchronous backpressure") {
+                let sequenceLength = 100
+                let subject = PassthroughSubject<Int, Never>()
+                let semaphore = DispatchSemaphore(value: 0)
+
+                let total = Atom<Int>(val: 0)
+                var collision = false
+                let c = subject
+                   .sink(receiveValue: { value in
+                    if total.isMutating {
+                         // Check to see if this closure is concurrently invoked
+                         collision = true
+                      }
+                    total.withLockMutating { total in
+                         // Make sure we're in the handler for enough time to get a concurrent invocation
+                         Thread.sleep(forTimeInterval: 0.001)
+                         total += value
+                         if total == sequenceLength {
+                            semaphore.signal()
+                         }
+                      }
+                   })
+
+                // Try to send from a hundred different threads at once
+                for _ in 1...sequenceLength {
+                   DispatchQueue.global().async {
+                      subject.send(1)
+                   }
+                }
+
+                semaphore.wait()
+                c.cancel()
+                expect(total.get()).to(be(sequenceLength))
+                expect(collision).to(beFalse())
+            }
         }
     }
 }


### PR DESCRIPTION
There is a bug in the two subjects `CurrentValueSubject` and `PassthroughSubject` that the sending of new values is not synchronised. Right now this is only adding the tests to verify but I am working on implementing a fix as well, if you have input how it should be fixed please let me know.