### PR TITLE
Remove CCombineX

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,9 @@ let package = Package(
     ],
     targets: [
         .target(name: "CXLibc"),
-        .target(name: "CCombineX"),
         .target(name: "CXUtility"),
         .target(name: "CXNamespace"),
-        .target(name: "CombineX", dependencies: ["CXLibc", "CCombineX", "CXUtility", "CXNamespace"]),
+        .target(name: "CombineX", dependencies: ["CXLibc", "CXUtility", "CXNamespace"]),
         .target(name: "CXFoundation", dependencies: ["CXUtility", "CXNamespace", "CombineX"]),
         .target(name: "CXCompatible", dependencies: ["CXNamespace"]),
         .target(name: "CXShim", dependencies: [/* depends on combine implementation */]),

--- a/Sources/CCombineX/dummy.c
+++ b/Sources/CCombineX/dummy.c
@@ -1,1 +1,0 @@
-// empty file, make SPM happy.

--- a/Sources/CCombineX/include/header.h
+++ b/Sources/CCombineX/include/header.h
@@ -1,1 +1,0 @@
-const void * _Nullable swift_getTypeByMangledNameInContext(const char * _Nullable typeNameStart, int typeNameLength, const void * _Nullable context, const void * _Nullable const * _Nullable genericArgs);


### PR DESCRIPTION
[Swift stdlib](https://github.com/apple/swift/blob/master/stdlib/public/core/Misc.swift#L106), [HandyJSON](https://github.com/alibaba/HandyJSON/blob/master/Source/CBridge.swift#L27) and [KakaJSON](https://github.com/kakaopensource/KakaJSON/blob/master/Sources/KakaJSON/Metadata/Descriptor/FieldDescriptor.swift#L68) also use `@_silgen_name` to expose swift runtime method. Actually `_getTypeByMangledNameInContext` is available in Swift stdlib. I re-declare it in case it get removed from stdlib.