### PR TITLE
adapt Apple's KVO publisher implementation

### DIFF
--- a/CombineX-Carthage.xcodeproj/project.pbxproj
+++ b/CombineX-Carthage.xcodeproj/project.pbxproj
@@ -146,6 +146,10 @@
 		3688F2042C6BC2CBFD891387 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52ECBBFE7B321A66BCAD2A38 /* LinkedList.swift */; };
 		3700E22254B6A2E018F3C7A2 /* TryLastWhere.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE688FAFE8CE1D5DA9B09BC5 /* TryLastWhere.swift */; };
 		374B1CD2D22326A90DB9A367 /* TryReduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEE74989D04FC478C1FE3C8 /* TryReduce.swift */; };
+		375AC699244F94F40034572B /* Publishers+KeyValueObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375AC698244F94F40034572B /* Publishers+KeyValueObserving.swift */; };
+		375AC69A244F94FC0034572B /* Publishers+KeyValueObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375AC698244F94F40034572B /* Publishers+KeyValueObserving.swift */; };
+		375AC69B244F94FC0034572B /* Publishers+KeyValueObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375AC698244F94F40034572B /* Publishers+KeyValueObserving.swift */; };
+		375AC69C244F94FC0034572B /* Publishers+KeyValueObserving.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375AC698244F94F40034572B /* Publishers+KeyValueObserving.swift */; };
 		377A4F05F453AF3344B6EF6D /* CompletionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14DFB87380A613489B7BD015 /* CompletionExtensions.swift */; };
 		37DBDC341A79CA7DD0561522 /* ImmediateScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BB86BC4DBA37EE6142DCC4 /* ImmediateScheduler.swift */; };
 		383B9597D07CA40CC7BABD3C /* Subscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476BB8EAEB94DB36AE0FFA7C /* Subscriber.swift */; };
@@ -832,6 +836,7 @@
 		35E3D98ED65630012D6FC492 /* Publishers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Publishers.swift; sourceTree = "<group>"; };
 		36423CA24908309C228FC304 /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		366663A736EC652D1DD3766D /* TryRemoveDuplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TryRemoveDuplicates.swift; sourceTree = "<group>"; };
+		375AC698244F94F40034572B /* Publishers+KeyValueObserving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publishers+KeyValueObserving.swift"; sourceTree = "<group>"; };
 		386B8E77C5C077C03D4D71AD /* SwitchToLatest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchToLatest.swift; sourceTree = "<group>"; };
 		3BEAC2918A4FBEA8B198CA39 /* Result.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		3F16FDD48420A62E48F28632 /* ObserableObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserableObject.swift; sourceTree = "<group>"; };
@@ -1164,6 +1169,7 @@
 				D06ABF8B30ABBC40409EF057 /* OperationQueue.swift */,
 				306645CAC17B650477A0B94E /* PropertyListDecoder.swift */,
 				772F387289B1579D03CF8329 /* PropertyListEncoder.swift */,
+				375AC698244F94F40034572B /* Publishers+KeyValueObserving.swift */,
 				8683D5747CC6FAAC85E968CD /* RunLoop.swift */,
 				6FA92DD4223C020F6C540926 /* Timer.swift */,
 				40E4C5A6947F4D619B7C54C8 /* URLSession.swift */,
@@ -1769,6 +1775,7 @@
 				2AF96B5776FDA3337D46F554 /* RunLoop.swift in Sources */,
 				0773871681DA7C7CC930B842 /* Timer.swift in Sources */,
 				AA5F25E322460EA639047302 /* URLSession.swift in Sources */,
+				375AC699244F94F40034572B /* Publishers+KeyValueObserving.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1823,6 +1830,7 @@
 				4D3A3FCA476CD8ABDFE46313 /* RunLoop.swift in Sources */,
 				D63DC29B707649D8D52CAA1A /* Timer.swift in Sources */,
 				EEC83803DA287DAAE34CB74E /* URLSession.swift in Sources */,
+				375AC69A244F94FC0034572B /* Publishers+KeyValueObserving.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2134,6 +2142,7 @@
 				13E0E8BDFFF360E852C337D9 /* RunLoop.swift in Sources */,
 				F403FC34109EDDBB3D2B7921 /* Timer.swift in Sources */,
 				2DD26FDFD2F76A0B4A0F8334 /* URLSession.swift in Sources */,
+				375AC69B244F94FC0034572B /* Publishers+KeyValueObserving.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2188,6 +2197,7 @@
 				62033F89029150905EE92F29 /* RunLoop.swift in Sources */,
 				898B4301998F7B368436E102 /* Timer.swift in Sources */,
 				CBD5AE8C6D08FD196E363E8D /* URLSession.swift in Sources */,
+				375AC69C244F94FC0034572B /* Publishers+KeyValueObserving.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------
+
+The following files are adapted from the Swift open source project:
+
+- Sources/CXFoundation/Publishers+KeyValueObserving.swift
+
+These files are under the Apache License version 2.0, found here:
+
+https://github.com/apple/swift/blob/4f3eab3aae55bd7ad2af710fd468d0361aa907da/LICENSE.txt
+

--- a/Sources/CXFoundation/NSObject.swift
+++ b/Sources/CXFoundation/NSObject.swift
@@ -17,7 +17,37 @@ extension CXWrappers {
     }
 }
 
-extension NSObject: CXWrapping {
-    
-    public typealias CX = CXWrappers.NSObject<NSObject>
+// The naïve conformance of NSObject to CXWrapping looks like this:
+//     extension CXWrapping where Self: Foundation.NSObject {
+//         public typealias CX = CXWrappers.NSObject<Self>
+//     }
+//
+//     extension NSObject: CXWrapping { }
+//
+// But that produces a cascade of errors, starting with this:
+//
+//     .../CombineX/Sources/CXFoundation/JSONDecoder.swift:22:1: error: type 'JSONDecoder' does not conform to protocol 'CXWrapping'
+//     extension JSONDecoder: CXWrapping {
+//     ^
+//     .../CombineX/Sources/CXNamespace/CXNamespace.swift:12:20: note: multiple matching types named 'CX'
+//         associatedtype CX
+//                        ^
+//     .../CombineX/Sources/CXFoundation/JSONDecoder.swift:24:22: note: possibly intended match
+//         public typealias CX = CXWrappers.JSONDecoder
+//                          ^
+//     .../CombineX/Sources/CXFoundation/NSObject.swift:21:22: note: possibly intended match
+//         public typealias CX = CXWrappers.NSObject<Self>
+//
+// I think the root problem might be that JSONDecoder (and several other types) somehow secretly subclass NSObject on Apple platforms, and so it tries to pick up two different definitions of `CX`.
+//
+// My workaround here is to *not* conform NSObject to CXWrapping at all.
+//
+// A different fix is to rework CXWrapper/CXWrapping entirely. They are analogous to RxSwift's Reactive/ReactiveCompatible types, and could be implemented the same way RxSwift does (with CXWrapper as a struct rather than a protocol). However, that fix would touch many more files instead of just this one.
+
+public protocol _CXNSObject { }
+
+extension NSObject: _CXNSObject { }
+
+extension _CXNSObject where Self: NSObject {
+    public var cx: CXWrappers.NSObject<Self> { .init(wrapping: self) }
 }

--- a/Sources/CXFoundation/NSObject.swift
+++ b/Sources/CXFoundation/NSObject.swift
@@ -21,34 +21,3 @@ extension NSObject: CXWrapping {
     
     public typealias CX = CXWrappers.NSObject<NSObject>
 }
-
-#if canImport(ObjectiveC)
-
-// FIXME: NSObject.KeyValueObservingPublisher doesn't conform ot `Publisher` protocol, 🤔.
-extension NSObject.CX {
-    
-    func keyValueObservingPublisher<Value>(_ keyPath: KeyPath<Base, Value>, _ options: NSKeyValueObservingOptions) -> KeyValueObservingPublisher<Base, Value> {
-        return .init(object: self.base, keyPath: keyPath, options: options)
-    }
-}
-
-extension NSObject.CX {
-    
-    /// A publisher that emits events when the value of a KVO-compliant property changes.
-    public struct KeyValueObservingPublisher<Subject, Value>: Equatable where Subject: NSObject {
-
-        public let object: Subject
-
-        public let keyPath: KeyPath<Subject, Value>
-
-        public let options: NSKeyValueObservingOptions
-
-        public init(object: Subject, keyPath: KeyPath<Subject, Value>, options: NSKeyValueObservingOptions) {
-            self.object = object
-            self.keyPath = keyPath
-            self.options = options
-        }
-    }
-}
-
-#endif

--- a/Sources/CXFoundation/Publishers+KeyValueObserving.swift
+++ b/Sources/CXFoundation/Publishers+KeyValueObserving.swift
@@ -1,0 +1,216 @@
+// Adapted from the original file:
+// https://github.com/apple/swift/blob/102bc6a2cd70f81d13c519718764bdcd7b8e3a6d/stdlib/public/Darwin/Foundation/Publishers%2BKeyValueObserving.swift
+
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Only support 64bit
+//#if !(os(iOS) && (arch(i386) || arch(arm)))
+#if canImport(ObjectiveC)
+
+import Foundation
+import CombineX
+import CXUtility
+
+// The following protocol is so that we can reference `Self` in the Publisher
+// below. This is based on a trick used in the the standard library's
+// implementation of `NSObject.observe(key path)`
+//@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public protocol _KeyValueCodingAndObservingPublishing {}
+
+//@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension NSObject: _KeyValueCodingAndObservingPublishing {}
+
+//@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension _KeyValueCodingAndObservingPublishing where Self: NSObject {
+    /// Publish values when the value identified by a KVO-compliant keypath changes.
+    ///
+    /// - Parameters:
+    ///   - keyPath: The keypath of the property to publish.
+    ///   - options: Key-value observing options.
+    /// - Returns: A publisher that emits elements each time the property’s value changes.
+    public func publisher<Value>(for keyPath: KeyPath<Self, Value>,
+                                 options: NSKeyValueObservingOptions = [.initial, .new])
+        -> CXWrappers.KeyValueObservingPublisher<Self, Value> {
+        return CXWrappers.KeyValueObservingPublisher(object: self, keyPath: keyPath, options: options)
+    }
+}
+
+//@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension CXWrappers.KeyValueObservingPublisher {
+    /// Returns a publisher that emits values when a KVO-compliant property changes.
+    ///
+    /// - Returns: A key-value observing publisher.
+    public func didChange()
+        -> Publishers.Map<CXWrappers.KeyValueObservingPublisher<Subject, Value>, Void> {
+        return map { _ in () }
+    }
+}
+
+//@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension CXWrappers{
+    /// A publisher that emits events when the value of a KVO-compliant property changes.
+    public struct KeyValueObservingPublisher<Subject: Foundation.NSObject, Value> : Equatable {
+        public let object: Subject
+        public let keyPath: KeyPath<Subject, Value>
+        public let options: NSKeyValueObservingOptions
+
+        public init(
+            object: Subject,
+            keyPath: KeyPath<Subject, Value>,
+            options: NSKeyValueObservingOptions
+        ) {
+            self.object = object
+            self.keyPath = keyPath
+            self.options = options
+        }
+
+        public static func == (
+            lhs: KeyValueObservingPublisher,
+            rhs: KeyValueObservingPublisher
+        ) -> Bool {
+            return lhs.object === rhs.object
+                && lhs.keyPath == rhs.keyPath
+                && lhs.options == rhs.options
+        }
+    }
+}
+
+//@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension CXWrappers.KeyValueObservingPublisher: Publisher {
+    public typealias Output = Value
+    public typealias Failure = Never
+
+    public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+        let s = CXWrappers.KVOSubscription(object, keyPath, options, subscriber)
+        subscriber.receive(subscription: s)
+    }
+}
+
+//@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension CXWrappers {
+    private final class KVOSubscription<Subject: Foundation.NSObject, Value>: Subscription, CustomStringConvertible, CustomReflectable, CustomPlaygroundDisplayConvertible {
+        private var observation: NSKeyValueObservation?         // GuardedBy(lock)
+        private var demand: Subscribers.Demand                  // GuardedBy(lock)
+
+        // for configurations that care about '.initial' we need to 'cache' the value to account for backpressure, along with whom to send it to
+        //
+        // TODO: in the future we might want to consider interjecting a temporary publisher that does this, so that all KVO subscriptions don't incur the cost.
+        private var receivedInitial: Bool                       // GuardedBy(lock)
+        private var last: Value?                                // GuardedBy(lock)
+        private var subscriber: AnySubscriber<Value, Never>?    // GuardedBy(lock)
+
+        private let lock = Lock()
+
+        // This lock can only be held for the duration of downstream callouts
+        private let downstreamLock = Lock(recursive: true)
+
+        var description: String { return "KVOSubscription" }
+        var customMirror: Mirror {
+            lock.lock()
+            defer { lock.unlock() }
+            return Mirror(self, children: [
+                "observation": observation as Any,
+                "demand": demand
+            ])
+        }
+        var playgroundDescription: Any { return description }
+
+        init<S: Subscriber>(
+            _ object: Subject,
+            _ keyPath: KeyPath<Subject, Value>,
+            _ options: NSKeyValueObservingOptions,
+            _ subscriber: S)
+            where
+                S.Input == Value,
+                S.Failure == Never
+        {
+            demand = .max(0)
+            receivedInitial = false
+            self.subscriber = AnySubscriber(subscriber)
+
+            observation = object.observe(
+                keyPath,
+                options: options
+            ) { [weak self] obj, _ in
+                guard let self = self else {
+                    return
+                }
+                let value = obj[keyPath: keyPath]
+                self.lock.lock()
+                if self.demand > 0, let sub = self.subscriber {
+                    self.demand -= 1
+                    self.lock.unlock()
+
+                    self.downstreamLock.lock()
+                    let additional = sub.receive(value)
+                    self.downstreamLock.unlock()
+
+                    self.lock.lock()
+                    self.demand += additional
+                    self.lock.unlock()
+                } else {
+                    // Drop the value, unless we've asked for .initial, and this
+                    // is the first value.
+                    if self.receivedInitial == false && options.contains(.initial) {
+                        self.last = value
+                        self.receivedInitial = true
+                    }
+                    self.lock.unlock()
+                }
+            }
+        }
+
+        deinit {
+//            lock.cleanupLock()
+//            downstreamLock.cleanupLock()
+        }
+
+        func request(_ d: Subscribers.Demand) {
+            lock.lock()
+            demand += d
+            if demand > 0, let v = last, let sub = subscriber {
+                demand -= 1
+                last = nil
+                lock.unlock()
+
+                downstreamLock.lock()
+                let additional = sub.receive(v)
+                downstreamLock.unlock()
+
+                lock.lock()
+                demand += additional
+            } else {
+                demand -= 1
+                last = nil
+            }
+            lock.unlock()
+        }
+
+        func cancel() {
+            lock.lock()
+            guard let o = observation else {
+                lock.unlock()
+                return
+            }
+            lock.unlock()
+
+            observation = nil
+            subscriber = nil
+            last = nil
+            o.invalidate()
+        }
+    }
+}
+
+#endif /* canImport(ObjectiveC) */
+//#endif /* !(os(iOS) && (arch(i386) || arch(arm))) */

--- a/Sources/CXFoundation/Publishers+KeyValueObserving.swift
+++ b/Sources/CXFoundation/Publishers+KeyValueObserving.swift
@@ -25,23 +25,23 @@ import CXUtility
 // below. This is based on a trick used in the the standard library's
 // implementation of `NSObject.observe(key path)`
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-public protocol _KeyValueCodingAndObservingPublishing {}
+//public protocol _KeyValueCodingAndObservingPublishing {}
 
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension NSObject: _KeyValueCodingAndObservingPublishing {}
+//extension NSObject: _KeyValueCodingAndObservingPublishing {}
 
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension _KeyValueCodingAndObservingPublishing where Self: NSObject {
+extension CXWrappers.NSObject {
     /// Publish values when the value identified by a KVO-compliant keypath changes.
     ///
     /// - Parameters:
     ///   - keyPath: The keypath of the property to publish.
     ///   - options: Key-value observing options.
     /// - Returns: A publisher that emits elements each time the property’s value changes.
-    public func publisher<Value>(for keyPath: KeyPath<Self, Value>,
+    public func publisher<Value>(for keyPath: KeyPath<Base, Value>,
                                  options: NSKeyValueObservingOptions = [.initial, .new])
-        -> CXWrappers.KeyValueObservingPublisher<Self, Value> {
-        return CXWrappers.KeyValueObservingPublisher(object: self, keyPath: keyPath, options: options)
+        -> CXWrappers.KeyValueObservingPublisher<Base, Value> {
+        return CXWrappers.KeyValueObservingPublisher(object: base, keyPath: keyPath, options: options)
     }
 }
 
@@ -57,7 +57,7 @@ extension CXWrappers.KeyValueObservingPublisher {
 }
 
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension CXWrappers{
+extension CXWrappers {
     /// A publisher that emits events when the value of a KVO-compliant property changes.
     public struct KeyValueObservingPublisher<Subject: Foundation.NSObject, Value> : Equatable {
         public let object: Subject

--- a/Sources/CXFoundation/Publishers+KeyValueObserving.swift
+++ b/Sources/CXFoundation/Publishers+KeyValueObserving.swift
@@ -40,24 +40,24 @@ extension CXWrappers.NSObject {
     /// - Returns: A publisher that emits elements each time the property’s value changes.
     public func publisher<Value>(for keyPath: KeyPath<Base, Value>,
                                  options: NSKeyValueObservingOptions = [.initial, .new])
-        -> CXWrappers.KeyValueObservingPublisher<Base, Value> {
-        return CXWrappers.KeyValueObservingPublisher(object: base, keyPath: keyPath, options: options)
+        -> CXWrappers.NSObject<Base>.KeyValueObservingPublisher<Base, Value> {
+        return CXWrappers.NSObject<Base>.KeyValueObservingPublisher(object: base, keyPath: keyPath, options: options)
     }
 }
 
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension CXWrappers.KeyValueObservingPublisher {
+extension CXWrappers.NSObject.KeyValueObservingPublisher {
     /// Returns a publisher that emits values when a KVO-compliant property changes.
     ///
     /// - Returns: A key-value observing publisher.
     public func didChange()
-        -> Publishers.Map<CXWrappers.KeyValueObservingPublisher<Subject, Value>, Void> {
+        -> Publishers.Map<CXWrappers.NSObject<Base>.KeyValueObservingPublisher<Subject, Value>, Void> {
         return map { _ in () }
     }
 }
 
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension CXWrappers {
+extension CXWrappers.NSObject {
     /// A publisher that emits events when the value of a KVO-compliant property changes.
     public struct KeyValueObservingPublisher<Subject: Foundation.NSObject, Value> : Equatable {
         public let object: Subject
@@ -86,18 +86,18 @@ extension CXWrappers {
 }
 
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension CXWrappers.KeyValueObservingPublisher: Publisher {
+extension CXWrappers.NSObject.KeyValueObservingPublisher: Publisher {
     public typealias Output = Value
     public typealias Failure = Never
 
     public func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
-        let s = CXWrappers.KVOSubscription(object, keyPath, options, subscriber)
+        let s = CXWrappers.NSObject.KVOSubscription(object, keyPath, options, subscriber)
         subscriber.receive(subscription: s)
     }
 }
 
 //@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-extension CXWrappers {
+extension CXWrappers.NSObject {
     private final class KVOSubscription<Subject: Foundation.NSObject, Value>: Subscription, CustomStringConvertible, CustomReflectable, CustomPlaygroundDisplayConvertible {
         private var observation: NSKeyValueObservation?         // GuardedBy(lock)
         private var demand: Subscribers.Demand                  // GuardedBy(lock)

--- a/Tests/CXFoundationTests/KeyValueObservingSpec.swift
+++ b/Tests/CXFoundationTests/KeyValueObservingSpec.swift
@@ -5,7 +5,7 @@ import Nimble
 import Quick
 
 class KeyValueObservingSpec: QuickSpec {
-    #if swift(>=5.1)
+    #if swift(>=5.1) && canImport(ObjectiveC)
 
     override func spec() {
 
@@ -104,5 +104,5 @@ class KeyValueObservingSpec: QuickSpec {
         @objc dynamic var p = 0
     }
 
-    #endif
+    #endif /* swift(>=5.1) && canImport(ObjectiveC) */
 }

--- a/Tests/CXFoundationTests/KeyValueObservingSpec.swift
+++ b/Tests/CXFoundationTests/KeyValueObservingSpec.swift
@@ -1,0 +1,108 @@
+import CXShim
+import CXTestUtility
+import Foundation
+import Nimble
+import Quick
+
+class KeyValueObservingSpec: QuickSpec {
+    #if swift(>=5.1)
+
+    override func spec() {
+
+        afterEach {
+            TestResources.release()
+        }
+
+        // Note that our implementation of the KVO publisher is a copy of Apple's open source code, so its behavior should be absolutely identical.
+
+        // MARK: - Publish
+        describe("Publish") {
+            // MARK: 1.1 should publish on assignments
+            it("should publish on assignments") {
+                let x = X()
+                let sub = makeTestSubscriber(Int.self, Never.self, .unlimited)
+                x.publisher(for: \.p, options: []).subscribe(sub)
+                expect(sub.eventsWithoutSubscription) == []
+                x.p = 1
+                x.p = 2
+                expect(sub.eventsWithoutSubscription) == [.value(1), .value(2)]
+            }
+
+            // MARK: 1.2 should publish immediately if .initial
+            it("should publish immediately if .initial") {
+                let x = X()
+                let sub = makeTestSubscriber(Int.self, Never.self, .unlimited)
+                x.publisher(for: \.p, options: [.initial]).subscribe(sub)
+                expect(sub.eventsWithoutSubscription) == [.value(0)]
+            }
+
+
+            // MARK: 1.2 should publish before also if .prior
+            it("should publish before also if .prior") {
+                let x = X()
+                let sub = makeTestSubscriber(Int.self, Never.self, .unlimited)
+                x.publisher(for: \.p, options: [.prior]).subscribe(sub)
+                expect(sub.eventsWithoutSubscription) == []
+                x.p = 1
+                x.p = 2
+                expect(sub.eventsWithoutSubscription) == [.value(0), .value(1), .value(1), .value(2)]
+            }
+
+            // MARK: 1.3 should publish immediately and before also if .initial and .prior
+            it("should publish immediately and before also if .initial and .prior") {
+                let x = X()
+                let sub = makeTestSubscriber(Int.self, Never.self, .unlimited)
+                x.publisher(for: \.p, options: [.initial, .prior]).subscribe(sub)
+                expect(sub.eventsWithoutSubscription) == [.value(0)]
+                x.p = 1
+                x.p = 2
+                expect(sub.eventsWithoutSubscription) == [.value(0), .value(0), .value(1), .value(1), .value(2)]
+            }
+        }
+
+        // MARK: - Demand
+        describe("Demand") {
+            // MARK: 2.1 should only send values when demand is not zero
+            it("should only send values when demand is not zero") {
+                let x = X()
+                let sub = TracingSubscriber<Int, Never>(
+                    receiveSubscription: { _ in },
+                    receiveValue: { _ in .none },
+                    receiveCompletion: { _ in }
+                )
+
+                // With .initial, the publisher caches the property value at subscription time until it receives its first non-zero demand.
+                x.publisher(for: \.p, options: [.initial]).subscribe(sub)
+
+                expect(sub.eventsWithoutSubscription) == []
+                x.p = 1
+                x.p = 2
+                expect(sub.eventsWithoutSubscription) == []
+                sub.subscription!.request(.max(1))
+                // x.p was 0 when I subscribed.
+                expect(sub.eventsWithoutSubscription) == [.value(0)]
+                x.p = 3
+                x.p = 4
+                sub.subscription!.request(.max(3))
+                x.p = 5
+                x.p = 6
+                x.p = 7
+                x.p = 8
+
+                // This is the "correct" expectation:
+                //
+                //     expect(sub.eventsWithoutSubscription) == [.value(0), .value(5), .value(6), .value(7)]
+                //
+                // But Apple's implementation is buggy! It always decrements the value given to `request(_:)` by 1. If you request 1, you get nothing. If you request 2, you get 1. And so on.
+                // I did not fix that bug when I adapted Apple's implementation for CombineX, so we exhibit the same bug. Here's the expectation that matches the buggy behavior:
+                expect(sub.eventsWithoutSubscription) == [.value(0), .value(5), .value(6)]
+            }
+        }
+    }
+
+    class X: NSObject {
+        @objc dynamic var p = 0
+    }
+
+    #endif
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -70,6 +70,7 @@ QCKMain([
     // MARK: - CXFoundation
     
     CoderSpec.self,
+    KeyValueObservingSpec.self,
     NotificationCenterSpec.self,
     SchedulerSpec.self,
     TimerSpec.self,


### PR DESCRIPTION
See #75. This commit adapts Apple's KVO publisher for CombineX.

Please note that Apple's implementation has a bug, which I did not fix in the adapted version. Test case 2.1 expects the buggy behavior, and has a comment describing the bug and what the correct behavior would be.
