### PR TITLE
Clean up storage of ObservableObjectPublisherCache in place.

### DIFF
--- a/Sources/CombineX/Internal/ObserableObjectCache.swift
+++ b/Sources/CombineX/Internal/ObserableObjectCache.swift
@@ -12,8 +12,8 @@ class ObservableObjectPublisherCache<Key: AnyObject, Value: AnyObject> {
     private var lock = Lock()
     
     private func cleanup() {
-        storage = storage.filter { key, value in
-            return key.value != nil && value.value != nil
+        for (key, value) in storage where key.value == nil || value.value == nil {
+            storage.removeValue(forKey: key)
         }
     }
     


### PR DESCRIPTION
Avoid creation of intermediate dictionary.