### PR TITLE
Update LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,14 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
---------------------------
-
-The following files are adapted from the Swift open source project:
-
-- Sources/CXFoundation/Publishers+KeyValueObserving.swift
-
-These files are under the Apache License version 2.0, found here:
-
-https://github.com/apple/swift/blob/4f3eab3aae55bd7ad2af710fd468d0361aa907da/LICENSE.txt
-

--- a/README.md
+++ b/README.md
@@ -54,3 +54,11 @@ These libraries bring additional functionality to Combine. They are all [Combine
 
 - [CXCocoa](https://github.com/cx-org/CXCocoa): provides `Combine` extensions to `Cocoa`, such as `KVO+Publisher`, `Method Interception`, `UIBinding`, `Delegate Proxy`, etc.
 - [CXExtensions](https://github.com/cx-org/CXExtensions): provides a collection of useful extensions for `Combine`, such as `IgnoreError`, `DelayedAutoCancellable`, etc.
+
+## License
+
+CombineX is released under the MIT license. See [LICENSE](LICENSE) for details.
+
+The following files are adapted from the Swift open source project:
+
+- [Publishers+KeyValueObserving](Sources/CXFoundation/Publishers+KeyValueObserving.swift)

--- a/README_zh-Hans.md
+++ b/README_zh-Hans.md
@@ -52,3 +52,11 @@ CXShim 仅在 Swift Package Manager 下可用。
 
 - [CXCocoa](https://github.com/cx-org/CXCocoa)：提供 `Cocoa` 的 `Combine` 扩展。例如 `KVO+Publisher`，`Method Interception`，`UIBinding`，`Delegate Proxy` 等。
 - [CXExtensions](https://github.com/cx-org/CXExtensions)：提供一系列有用的 Combine 扩展，例如：`IgnoreError`，`DelayedAutoCancellable` 等。
+
+## 许可协议
+
+CombineX 以 MIT 协议发布. 查看 [LICENSE](LICENSE) 获取更多信息.
+
+以下文件取自 Swift 项目:
+
+- [Publishers+KeyValueObserving](Sources/CXFoundation/Publishers+KeyValueObserving.swift)


### PR DESCRIPTION
GitHub can't recognize license file:
<img width="141" alt="image" src="https://user-images.githubusercontent.com/11691433/86461564-c05a3680-bd5c-11ea-9ee3-5f3029f1688f.png">
Use unmodified MIT license instead:
<img width="128" alt="image" src="https://user-images.githubusercontent.com/11691433/86461620-d9fb7e00-bd5c-11ea-8555-6a3ba667f7c7.png">

