### PR TITLE
Set iOS deployment target to 9 for Swift >= 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -140,7 +140,7 @@ testUtilityTarget.swiftSettings.append(contentsOf: combineImp.swiftSettings)
 if combineImp == .combine && isCI {
     package.platforms = [.macOS("10.15"), .iOS("13.0"), .tvOS("13.0"), .watchOS("6.0")]
 } else {
-    #if swift(>=5.3)
+    #if compiler(>=5.3)
     package.platforms = [.macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)]
     #endif
 }

--- a/Package.swift
+++ b/Package.swift
@@ -139,4 +139,8 @@ testUtilityTarget.swiftSettings.append(contentsOf: combineImp.swiftSettings)
 
 if combineImp == .combine && isCI {
     package.platforms = [.macOS("10.15"), .iOS("13.0"), .tvOS("13.0"), .watchOS("6.0")]
+} else {
+    #if swift(>=5.3)
+    package.platforms = [.macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v2)]
+    #endif
 }


### PR DESCRIPTION
Xcode 12 ships with 5.3 but also drops iOS 8 support. This causes a warning ("The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.2.99.")