### PR TITLE
Implement new interface from Xcode12

### DIFF
--- a/Sources/CXCompatible/Polyfill/FlatMap.swift
+++ b/Sources/CXCompatible/Polyfill/FlatMap.swift
@@ -1,0 +1,82 @@
+#if canImport(Combine)
+
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publisher {
+    
+    /// Transforms all elements from an upstream publisher into a new publisher
+    /// up to a maximum number of publishers you specify.
+    ///
+    /// - Parameters:
+    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
+    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
+    ///   unspecified.
+    ///   - transform: A closure that takes an element as a parameter and
+    ///   returns a publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream
+    /// publisher into a publisher of that element’s type.
+    @available(macOS, obsoleted: 11.0)
+    @available(iOS, obsoleted: 14.0)
+    @available(tvOS, obsoleted: 14.0)
+    @available(watchOS, obsoleted: 7.0)
+    public func flatMap<P>(
+        maxPublishers: Subscribers.Demand = .unlimited,
+        _ transform: @escaping (Output) -> P
+    ) -> Publishers.FlatMap<Publishers.SetFailureType<P, Failure>, Self> where P: Publisher, P.Failure == Never {
+        return .init(upstream: self, maxPublishers: maxPublishers) {
+            transform($0).setFailureType(to: Failure.self)
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publisher where Failure == Never {
+    
+    /// Transforms all elements from an upstream publisher into a new publisher
+    /// up to a maximum number of publishers you specify.
+    ///
+    /// - Parameters:
+    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
+    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
+    ///   unspecified.
+    ///   - transform: A closure that takes an element as a parameter and
+    ///   returns a publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream
+    /// publisher into a publisher of that element’s type.
+    @available(macOS, obsoleted: 11.0)
+    @available(iOS, obsoleted: 14.0)
+    @available(tvOS, obsoleted: 14.0)
+    @available(watchOS, obsoleted: 7.0)
+    public func flatMap<P>(
+        maxPublishers: Subscribers.Demand = .unlimited,
+        _ transform: @escaping (Output) -> P
+    ) -> Publishers.FlatMap<P, Publishers.SetFailureType<Self, P.Failure>> where P: Publisher {
+        return setFailureType(to: P.Failure.self)
+            .flatMap(maxPublishers: maxPublishers, transform)
+    }
+    
+    /// Transforms all elements from an upstream publisher into a new publisher
+    /// up to a maximum number of publishers you specify.
+    ///
+    /// - Parameters:
+    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
+    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
+    ///   unspecified.
+    ///   - transform: A closure that takes an element as a parameter and
+    ///   returns a publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream
+    /// publisher into a publisher of that element’s type.
+    @available(macOS, obsoleted: 11.0)
+    @available(iOS, obsoleted: 14.0)
+    @available(tvOS, obsoleted: 14.0)
+    @available(watchOS, obsoleted: 7.0)
+    public func flatMap<P>(
+        maxPublishers: Subscribers.Demand = .unlimited,
+        _ transform: @escaping (Output) -> P
+    ) -> Publishers.FlatMap<P, Self> where P: Publisher, P.Failure == Never {
+        return .init(upstream: self, maxPublishers: maxPublishers, transform: transform)
+    }
+}
+
+#endif

--- a/Sources/CXCompatible/Polyfill/Optional.swift
+++ b/Sources/CXCompatible/Polyfill/Optional.swift
@@ -1,0 +1,16 @@
+#if canImport(Combine)
+
+import Combine
+
+extension Optional {
+    
+    @available(macOS, introduced: 10.15, obsoleted: 11.0)
+    @available(iOS, introduced: 13.0, obsoleted: 14.0)
+    @available(tvOS, introduced: 13.0, obsoleted: 14.0)
+    @available(watchOS, introduced: 6.0, obsoleted: 7.0)
+    public var publisher: Publisher {
+        return Publisher(self)
+    }
+}
+
+#endif

--- a/Sources/CombineX/Publishers/B/FlatMap.swift
+++ b/Sources/CombineX/Publishers/B/FlatMap.swift
@@ -4,20 +4,121 @@ import CXUtility
 
 extension Publisher {
     
-    /// Transforms all elements from an upstream publisher into a new or existing publisher.
+    /// Transforms all elements from an upstream publisher into a new publisher
+    /// up to a maximum number of publishers you specify.
     ///
-    /// `flatMap` merges the output from all returned publishers into a single stream of output.
+    /// Combine‘s ``Publisher/flatMap(maxPublishers:_:)`` operator performs a
+    /// similar function to the ``Sequence.flatmap(_:) operator`` in the Swift
+    /// standard library, but turns the elements from one kind of publisher into
+    /// a new publisher that is sent to subscribers. Use
+    /// ``Publisher/flatMap(maxPublishers:_:)`` when you want to create a new
+    /// series of events for downstream subscribers based on the received value.
+    /// The closure creates the new ``Publisher`` based on the received value.
+    /// The new ``Publisher`` can emit more than one event, and successful
+    /// completion of the new ``Publisher`` does not complete the overall stream.
+    /// Failure of the new ``Publisher`` will fail the overall stream.
+    ///
+    /// In the example below, a ``PassthroughSubject`` publishes `WeatherStation`
+    /// elements. The ``Publisher/flatMap(maxPublishers:_:)`` receives each
+    /// element, creates a ``URL`` from it, and produces a new
+    /// ``DataTaskPublisher``, which will publish the data loaded from that
+    /// ``URL``.
+    ///
+    ///     public struct WeatherStation {
+    ///         public let stationID: String
+    ///     }
+    ///
+    ///     var weatherPublisher = PassthroughSubject<WeatherStation, URLError>()
+    ///
+    ///     cancellable = weatherPublisher.flatMap { station -> URLSession.DataTaskPublisher in
+    ///         let url = URL(string:"https://weatherapi.example.com/stations/\(station.stationID)/observations/latest")!
+    ///         return URLSession.shared.dataTaskPublisher(for: url)
+    ///     }
+    ///     .sink(
+    ///         receiveCompletion: { completion in
+    ///             // Handle publisher completion (normal or error).
+    ///         },
+    ///         receiveValue: {
+    ///             // Process the received data.
+    ///         }
+    ///      )
+    ///
+    ///     weatherPublisher.send(WeatherStation(stationID: "KSFO")) // San Francisco, CA
+    ///     weatherPublisher.send(WeatherStation(stationID: "EGLC")) // London, UK
+    ///     weatherPublisher.send(WeatherStation(stationID: "ZBBB")) // Beijing, CN
     ///
     /// - Parameters:
-    ///   - maxPublishers: The maximum number of publishers produced by this method.
-    ///   - transform: A closure that takes an element as a parameter and returns a publisher
-    /// that produces elements of that type.
-    /// - Returns: A publisher that transforms elements from an upstream publisher into
-    /// a publisher of that element’s type.
+    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
+    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
+    ///   unspecified.
+    ///   - transform: A closure that takes an element as a parameter and
+    ///   returns a publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream
+    /// publisher into a publisher of that element’s type.
     public func flatMap<T, P>(
         maxPublishers: Subscribers.Demand = .unlimited,
         _ transform: @escaping (Output) -> P
     ) -> Publishers.FlatMap<P, Self> where T == P.Output, P: Publisher, Failure == P.Failure {
+        return .init(upstream: self, maxPublishers: maxPublishers, transform: transform)
+    }
+    
+    /// Transforms all elements from an upstream publisher into a new publisher
+    /// up to a maximum number of publishers you specify.
+    ///
+    /// - Parameters:
+    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
+    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
+    ///   unspecified.
+    ///   - transform: A closure that takes an element as a parameter and
+    ///   returns a publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream
+    /// publisher into a publisher of that element’s type.
+    public func flatMap<P>(
+        maxPublishers: Subscribers.Demand = .unlimited,
+        _ transform: @escaping (Output) -> P
+    ) -> Publishers.FlatMap<Publishers.SetFailureType<P, Failure>, Self> where P: Publisher, P.Failure == Never {
+        return .init(upstream: self, maxPublishers: maxPublishers) {
+            transform($0).setFailureType(to: Failure.self)
+        }
+    }
+}
+
+extension Publisher where Failure == Never {
+    
+    /// Transforms all elements from an upstream publisher into a new publisher
+    /// up to a maximum number of publishers you specify.
+    ///
+    /// - Parameters:
+    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
+    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
+    ///   unspecified.
+    ///   - transform: A closure that takes an element as a parameter and
+    ///   returns a publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream
+    /// publisher into a publisher of that element’s type.
+    public func flatMap<P>(
+        maxPublishers: Subscribers.Demand = .unlimited,
+        _ transform: @escaping (Output) -> P
+    ) -> Publishers.FlatMap<P, Publishers.SetFailureType<Self, P.Failure>> where P: Publisher {
+        return setFailureType(to: P.Failure.self)
+            .flatMap(maxPublishers: maxPublishers, transform)
+    }
+    
+    /// Transforms all elements from an upstream publisher into a new publisher
+    /// up to a maximum number of publishers you specify.
+    ///
+    /// - Parameters:
+    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
+    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
+    ///   unspecified.
+    ///   - transform: A closure that takes an element as a parameter and
+    ///   returns a publisher that produces elements of that type.
+    /// - Returns: A publisher that transforms elements from an upstream
+    /// publisher into a publisher of that element’s type.
+    public func flatMap<P>(
+        maxPublishers: Subscribers.Demand = .unlimited,
+        _ transform: @escaping (Output) -> P
+    ) -> Publishers.FlatMap<P, Self> where P: Publisher, P.Failure == Never {
         return .init(upstream: self, maxPublishers: maxPublishers, transform: transform)
     }
 }

--- a/Sources/CombineX/Publishers/B/Optional.Publisher.swift
+++ b/Sources/CombineX/Publishers/B/Optional.Publisher.swift
@@ -24,6 +24,13 @@ extension Optional: CXWrapping {
 
 extension Optional.CX {
     
+    public var publisher: Publisher {
+        return .init(self.base)
+    }
+}
+
+extension Optional.CX {
+    
     /// A publisher that publishes an optional value to each subscriber exactly once, if the optional has a value.
     ///
     /// In contrast with `Just`, an `Optional` publisher may send no value before completion.

--- a/Tests/CombineXTests/Publishers/FlatMapSpec.swift
+++ b/Tests/CombineXTests/Publishers/FlatMapSpec.swift
@@ -132,5 +132,15 @@ class FlatMapSpec: QuickSpec {
                 expect(sub.eventsWithoutSubscription.count) == 10
             }
         }
+        
+        // MARK: - Overloads
+        describe("Overloads") {
+            
+            it("convenient overloads for setting failure type") {
+                _ = Just(0).flatMap { _ in Fail<Bool, TestError>(error: .e0) }
+                _ = Fail<Bool, TestError>(error: .e0).flatMap { _ in Just(0) }
+                _ = Just(0).flatMap { _ in Just("") }
+            }
+        }
     }
 }

--- a/Tests/CombineXTests/Publishers/OptionalSpec.swift
+++ b/Tests/CombineXTests/Publishers/OptionalSpec.swift
@@ -48,11 +48,6 @@ class OptionalSpec: QuickSpec {
             #endif
             
             it("Optional provide publisher property since macOS 11") {
-                #if USE_COMBINE
-                guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
-                    return
-                }
-                #endif
                 let pub = Optional(11).cx.publisher
                 assert(pub == OptionalPublisher(11))
             }

--- a/Tests/CombineXTests/Publishers/OptionalSpec.swift
+++ b/Tests/CombineXTests/Publishers/OptionalSpec.swift
@@ -46,6 +46,16 @@ class OptionalSpec: QuickSpec {
                 }.toNot(throwAssertion())
             }
             #endif
+            
+            it("Optional provide publisher property since macOS 11") {
+                #if USE_COMBINE
+                guard #available(macOS 11.0, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+                    return
+                }
+                #endif
+                let pub = Optional(11).cx.publisher
+                assert(pub == OptionalPublisher(11))
+            }
         }
     }
 }


### PR DESCRIPTION
[Publisher.assign(to:)](https://developer.apple.com/documentation/combine/publisher/assign(to:)) and [Published.projectedValue:setter](https://developer.apple.com/documentation/combine/published/projectedvalue) is not included as they can't be added for Combine as polyfill.