### PR TITLE
Implement remaining new interface from Xcode12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           swift -version
           swift package --version
+          xcodebuild -version
       - name: Build and Test
         run: swift test
 
@@ -76,6 +77,7 @@ jobs:
       - name: Swift Version
         run: |
           sw_vers -productVersion
+          xcodebuild -version
           swift -version
           swift package --version
       - name: Build and Test

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -133,8 +133,8 @@ let shimTarget = package.targets.first(where: { $0.name == "CXShim" })!
 shimTarget.dependencies = combineImp.shimTargetDependencies
 shimTarget.swiftSettings.append(contentsOf: combineImp.swiftSettings)
 
-let testUtilityTarget = package.targets.first(where: { $0.name == "CXTestUtility" })!
-testUtilityTarget.swiftSettings.append(contentsOf: combineImp.swiftSettings)
+let testTargets = package.targets.filter { $0.name == "CXTestUtility" || $0.isTest }
+testTargets.forEach { $0.swiftSettings.append(contentsOf: combineImp.swiftSettings) }
 
 if combineImp == .combine && isCI {
     package.platforms = [.macOS("10.15"), .iOS("13.0"), .tvOS("13.0"), .watchOS("6.0")]

--- a/Sources/CXCompatible/Polyfill/FlatMap.swift
+++ b/Sources/CXCompatible/Polyfill/FlatMap.swift
@@ -5,17 +5,6 @@ import Combine
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher {
     
-    /// Transforms all elements from an upstream publisher into a new publisher
-    /// up to a maximum number of publishers you specify.
-    ///
-    /// - Parameters:
-    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
-    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
-    ///   unspecified.
-    ///   - transform: A closure that takes an element as a parameter and
-    ///   returns a publisher that produces elements of that type.
-    /// - Returns: A publisher that transforms elements from an upstream
-    /// publisher into a publisher of that element’s type.
     @available(macOS, obsoleted: 11.0)
     @available(iOS, obsoleted: 14.0)
     @available(tvOS, obsoleted: 14.0)
@@ -33,17 +22,6 @@ extension Publisher {
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Failure == Never {
     
-    /// Transforms all elements from an upstream publisher into a new publisher
-    /// up to a maximum number of publishers you specify.
-    ///
-    /// - Parameters:
-    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
-    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
-    ///   unspecified.
-    ///   - transform: A closure that takes an element as a parameter and
-    ///   returns a publisher that produces elements of that type.
-    /// - Returns: A publisher that transforms elements from an upstream
-    /// publisher into a publisher of that element’s type.
     @available(macOS, obsoleted: 11.0)
     @available(iOS, obsoleted: 14.0)
     @available(tvOS, obsoleted: 14.0)
@@ -56,17 +34,6 @@ extension Publisher where Failure == Never {
             .flatMap(maxPublishers: maxPublishers, transform)
     }
     
-    /// Transforms all elements from an upstream publisher into a new publisher
-    /// up to a maximum number of publishers you specify.
-    ///
-    /// - Parameters:
-    ///   - maxPublishers: Specifies the maximum number of concurrent publisher
-    ///   subscriptions, or ``Combine/Subscribers/Demand/unlimited`` if
-    ///   unspecified.
-    ///   - transform: A closure that takes an element as a parameter and
-    ///   returns a publisher that produces elements of that type.
-    /// - Returns: A publisher that transforms elements from an upstream
-    /// publisher into a publisher of that element’s type.
     @available(macOS, obsoleted: 11.0)
     @available(iOS, obsoleted: 14.0)
     @available(tvOS, obsoleted: 14.0)

--- a/Sources/CXCompatible/Polyfill/SwitchToLatest.swift
+++ b/Sources/CXCompatible/Polyfill/SwitchToLatest.swift
@@ -4,19 +4,7 @@ import Combine
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Output: Publisher, Output.Failure == Never {
-
-    /// Republishes elements sent by the most recently received publisher.
-    ///
-    /// This operator works with an upstream publisher of publishers, flattening
-    /// the stream of elements to appear as if they were coming from a single
-    /// stream of elements. It switches the inner publisher as new ones arrive
-    /// but keeps the outer publisher constant for downstream subscribers.
-    ///
-    /// When this operator receives a new publisher from the upstream publisher,
-    /// it cancels its previous subscription. Use this feature to prevent
-    /// earlier publishers from performing unnecessary work, such as creating
-    /// network request publishers from frequently updating user interface
-    /// publishers.
+    
     @available(macOS, obsoleted: 11.0)
     @available(iOS, obsoleted: 14.0)
     @available(tvOS, obsoleted: 14.0)
@@ -29,19 +17,7 @@ extension Publisher where Output: Publisher, Output.Failure == Never {
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Failure == Never, Output: Publisher {
-
-    /// Republishes elements sent by the most recently received publisher.
-    ///
-    /// This operator works with an upstream publisher of publishers, flattening
-    /// the stream of elements to appear as if they were coming from a single
-    /// stream of elements. It switches the inner publisher as new ones arrive
-    /// but keeps the outer publisher constant for downstream subscribers.
-    ///
-    /// When this operator receives a new publisher from the upstream publisher,
-    /// it cancels its previous subscription. Use this feature to prevent
-    /// earlier publishers from performing unnecessary work, such as creating
-    /// network request publishers from frequently updating user interface
-    /// publishers.
+    
     @available(macOS, obsoleted: 11.0)
     @available(iOS, obsoleted: 14.0)
     @available(tvOS, obsoleted: 14.0)
@@ -54,12 +30,7 @@ extension Publisher where Failure == Never, Output: Publisher {
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension Publisher where Failure == Never, Output: Publisher, Output.Failure == Never {
-
-    /// Republishes elements sent by the most recently received publisher.
-    ///
-    /// This operator works with an upstream publisher of publishers, flattening the stream of elements to appear as if they were coming from a single stream of elements. It switches the inner publisher as new ones arrive but keeps the outer publisher constant for downstream subscribers.
-    ///
-    /// When this operator receives a new publisher from the upstream publisher, it cancels its previous subscription. Use this feature to prevent earlier publishers from performing unnecessary work, such as creating network request publishers from frequently updating user interface publishers.
+    
     @available(macOS, obsoleted: 11.0)
     @available(iOS, obsoleted: 14.0)
     @available(tvOS, obsoleted: 14.0)

--- a/Sources/CXCompatible/Polyfill/SwitchToLatest.swift
+++ b/Sources/CXCompatible/Polyfill/SwitchToLatest.swift
@@ -1,0 +1,72 @@
+#if canImport(Combine)
+
+import Combine
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publisher where Output: Publisher, Output.Failure == Never {
+
+    /// Republishes elements sent by the most recently received publisher.
+    ///
+    /// This operator works with an upstream publisher of publishers, flattening
+    /// the stream of elements to appear as if they were coming from a single
+    /// stream of elements. It switches the inner publisher as new ones arrive
+    /// but keeps the outer publisher constant for downstream subscribers.
+    ///
+    /// When this operator receives a new publisher from the upstream publisher,
+    /// it cancels its previous subscription. Use this feature to prevent
+    /// earlier publishers from performing unnecessary work, such as creating
+    /// network request publishers from frequently updating user interface
+    /// publishers.
+    @available(macOS, obsoleted: 11.0)
+    @available(iOS, obsoleted: 14.0)
+    @available(tvOS, obsoleted: 14.0)
+    @available(watchOS, obsoleted: 7.0)
+    public func switchToLatest() -> Publishers.SwitchToLatest<Publishers.SetFailureType<Output, Failure>, Publishers.Map<Self, Publishers.SetFailureType<Output, Failure>>> {
+        return map { $0.setFailureType(to: Failure.self) }
+            .switchToLatest()
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publisher where Failure == Never, Output: Publisher {
+
+    /// Republishes elements sent by the most recently received publisher.
+    ///
+    /// This operator works with an upstream publisher of publishers, flattening
+    /// the stream of elements to appear as if they were coming from a single
+    /// stream of elements. It switches the inner publisher as new ones arrive
+    /// but keeps the outer publisher constant for downstream subscribers.
+    ///
+    /// When this operator receives a new publisher from the upstream publisher,
+    /// it cancels its previous subscription. Use this feature to prevent
+    /// earlier publishers from performing unnecessary work, such as creating
+    /// network request publishers from frequently updating user interface
+    /// publishers.
+    @available(macOS, obsoleted: 11.0)
+    @available(iOS, obsoleted: 14.0)
+    @available(tvOS, obsoleted: 14.0)
+    @available(watchOS, obsoleted: 7.0)
+    public func switchToLatest() -> Publishers.SwitchToLatest<Output, Publishers.SetFailureType<Self, Output.Failure>> {
+        return setFailureType(to: Output.Failure.self)
+            .switchToLatest()
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+extension Publisher where Failure == Never, Output: Publisher, Output.Failure == Never {
+
+    /// Republishes elements sent by the most recently received publisher.
+    ///
+    /// This operator works with an upstream publisher of publishers, flattening the stream of elements to appear as if they were coming from a single stream of elements. It switches the inner publisher as new ones arrive but keeps the outer publisher constant for downstream subscribers.
+    ///
+    /// When this operator receives a new publisher from the upstream publisher, it cancels its previous subscription. Use this feature to prevent earlier publishers from performing unnecessary work, such as creating network request publishers from frequently updating user interface publishers.
+    @available(macOS, obsoleted: 11.0)
+    @available(iOS, obsoleted: 14.0)
+    @available(tvOS, obsoleted: 14.0)
+    @available(watchOS, obsoleted: 7.0)
+    public func switchToLatest() -> Publishers.SwitchToLatest<Output, Self> {
+        return .init(upstream: self)
+    }
+}
+
+#endif

--- a/Sources/CombineX/Internal/Runtime.swift
+++ b/Sources/CombineX/Internal/Runtime.swift
@@ -6,7 +6,7 @@ struct PublishedFieldsEnumerator: Sequence {
     
     struct Iterator: IteratorProtocol {
         
-        typealias Element = (storage: UnsafeMutableRawPointer, type: _PublishedProtocol.Type)
+        typealias Element = (storage: UnsafeMutableRawPointer, type: _ObservableObjectProperty.Type)
         
         private let object: UnsafeMutableRawPointer
         private var inheritanceIterator: InheritanceSequence.Iterator
@@ -19,7 +19,7 @@ struct PublishedFieldsEnumerator: Sequence {
         
         mutating func next() -> Element? {
             while let (offset, type) = nextField() {
-                if let pType = type as? _PublishedProtocol.Type {
+                if let pType = type as? _ObservableObjectProperty.Type {
                     let storage = object.advanced(by: offset)
                     return (storage, pType)
                 }

--- a/Sources/CombineX/ObserableObject.swift
+++ b/Sources/CombineX/ObserableObject.swift
@@ -33,8 +33,6 @@ public protocol ObservableObject: AnyObject {
     var objectWillChange: ObjectWillChangePublisher { get }
 }
 
-private let globalObjectWillChangeCache = ObservableObjectPublisherCache<AnyObject, ObservableObjectPublisher>()
-
 extension ObservableObject where ObjectWillChangePublisher == ObservableObjectPublisher {
     
     public var objectWillChange: ObservableObjectPublisher {
@@ -83,3 +81,28 @@ public final class ObservableObjectPublisher: Publisher {
         self.subject.send()
     }
 }
+
+// MARK: - Helpers
+
+private let globalObjectWillChangeCache = ObservableObjectPublisherCache<AnyObject, ObservableObjectPublisher>()
+
+protocol _ObservableObjectProperty {
+    var objectWillChange: ObservableObjectPublisher? { get set }
+}
+
+private extension _ObservableObjectProperty {
+    
+    static func getPublisher(for ptr: UnsafeMutableRawPointer) -> ObservableObjectPublisher? {
+        return ptr.assumingMemoryBound(to: Self.self)
+            .pointee
+            .objectWillChange
+    }
+    
+    static func setPublisher(_ publisher: ObservableObjectPublisher, on ptr: UnsafeMutableRawPointer) {
+        ptr.assumingMemoryBound(to: Self.self)
+            .pointee
+            .objectWillChange = publisher
+    }
+}
+
+extension Published: _ObservableObjectProperty {}

--- a/Sources/CombineX/Published.swift
+++ b/Sources/CombineX/Published.swift
@@ -67,25 +67,4 @@
     }
 }
 
-protocol _PublishedProtocol {
-    var objectWillChange: ObservableObjectPublisher? { get set }
-}
-
-extension _PublishedProtocol {
-    
-    static func getPublisher(for ptr: UnsafeMutableRawPointer) -> ObservableObjectPublisher? {
-        return ptr.assumingMemoryBound(to: Self.self)
-            .pointee
-            .objectWillChange
-    }
-    
-    static func setPublisher(_ publisher: ObservableObjectPublisher, on ptr: UnsafeMutableRawPointer) {
-        ptr.assumingMemoryBound(to: Self.self)
-            .pointee
-            .objectWillChange = publisher
-    }
-}
-
-extension Published: _PublishedProtocol {}
-
 #endif

--- a/Tests/CombineXTests/PublishedSpec.swift
+++ b/Tests/CombineXTests/PublishedSpec.swift
@@ -14,18 +14,76 @@ class PublishedSpec: QuickSpec {
             
             // MARK: 1.1 should publish value's change
             it("Publish") {
-                class X {
-                    @Published var name = 0
-                }
-                let x = X()
-                let sub = x.$name.subscribeTracingSubscriber(initialDemand: .unlimited)
+                let obj = TestObject()
+                let sub = obj.$value.subscribeTracingSubscriber(initialDemand: .unlimited)
 
                 expect(sub.eventsWithoutSubscription) == [.value(0)]
                 
-                x.name = 1
-                x.name = 2
+                obj.value = 1
+                obj.value = 2
                 
                 expect(sub.eventsWithoutSubscription) == [.value(0), .value(1), .value(2)]
+            }
+            
+            it("test assign(to:) on Published.Publisher") {
+                #if USE_COMBINE
+                guard #available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+                    return
+                }
+                #endif
+                
+                weak var weakObj: TestObject?
+                
+                do {
+                    let pub = TracingSubject<Int, Never>()
+                    let obj = TestObject()
+                    weakObj = obj
+                    pub.assign(to: &obj.$value)
+                    
+                    expect(obj.value) == 0
+                    expect(pub.subscription.demandRecords) == [.unlimited]
+                    pub.send(1)
+                    expect(obj.value) == 1
+                    expect(pub.subscription.demandRecords) == [.unlimited, .none]
+                }
+                
+                expect(weakObj).to(beNil())
+            }
+            
+            it("projectedValue:setter doesn't have observable effect") {
+                #if USE_COMBINE
+                guard #available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
+                    return
+                }
+                #endif
+                
+                let obj1 = TestObject(value: 1)
+                let obj2 = TestObject(value: 2)
+                
+                expect(obj1.value) == 1
+                expect(obj2.value) == 2
+                
+                let sub1 = obj1.$value.subscribeTracingSubscriber(initialDemand: .unlimited)
+                let sub2 = obj2.$value.subscribeTracingSubscriber(initialDemand: .unlimited)
+                
+                expect(sub1.eventsWithoutSubscription) == [.value(1)]
+                expect(sub2.eventsWithoutSubscription) == [.value(2)]
+                
+                obj1.$value = obj2.$value
+                
+                let newSub1 = obj1.$value.subscribeTracingSubscriber(initialDemand: .unlimited)
+                let newSub2 = obj2.$value.subscribeTracingSubscriber(initialDemand: .unlimited)
+                
+                expect(newSub1.eventsWithoutSubscription) == [.value(1)]
+                expect(newSub2.eventsWithoutSubscription) == [.value(2)]
+                
+                obj1.value = 3
+                obj2.value = 4
+                
+                expect(sub1.eventsWithoutSubscription) == [.value(1), .value(3)]
+                expect(sub2.eventsWithoutSubscription) == [.value(2), .value(4)]
+                expect(newSub1.eventsWithoutSubscription) == [.value(1), .value(3)]
+                expect(newSub2.eventsWithoutSubscription) == [.value(2), .value(4)]
             }
         }
         
@@ -34,21 +92,28 @@ class PublishedSpec: QuickSpec {
             
             // MARK: 2.1 should send as many values as demand
             it("should send as many values as demand") {
-                class X {
-                    @Published var name = 0
-                }
-                let x = X()
-                let sub = x.$name.subscribeTracingSubscriber(initialDemand: .max(10)) { v in
+                let obj = TestObject()
+                let sub = obj.$value.subscribeTracingSubscriber(initialDemand: .max(10)) { v in
                     return [0, 10].contains(v) ? .max(1) : .max(0)
                 }
 
                 100.times {
-                    x.name = $0
+                    obj.value = $0
                 }
                 
                 expect(sub.eventsWithoutSubscription.count) == 13
             }
         }
     }
+    
+    class TestObject {
+        
+        @Published var value: Int
+        
+        init(value: Int = 0) {
+            _value = Published(wrappedValue: value)
+        }
+    }
+    
     #endif
 }

--- a/Tests/CombineXTests/PublishedSpec.swift
+++ b/Tests/CombineXTests/PublishedSpec.swift
@@ -25,6 +25,9 @@ class PublishedSpec: QuickSpec {
                 expect(sub.eventsWithoutSubscription) == [.value(0), .value(1), .value(2)]
             }
             
+            // needs macOS 11 SDK (Xcode 12.2), check swift toolchain varion instead.
+            #if compiler(>=5.3.1)
+            
             it("test assign(to:) on Published.Publisher") {
                 #if USE_COMBINE
                 guard #available(macOS 11, iOS 14.0, tvOS 14.0, watchOS 7.0, *) else {
@@ -85,6 +88,8 @@ class PublishedSpec: QuickSpec {
                 expect(newSub1.eventsWithoutSubscription) == [.value(1), .value(3)]
                 expect(newSub2.eventsWithoutSubscription) == [.value(2), .value(4)]
             }
+            
+            #endif // compiler(>=5.3.1)
         }
         
         // MARK: - Demand

--- a/Tests/CombineXTests/Publishers/SwitchToLatestSpec.swift
+++ b/Tests/CombineXTests/Publishers/SwitchToLatestSpec.swift
@@ -102,5 +102,15 @@ class SwitchToLatestSpec: QuickSpec {
                 _ = sub
             }
         }
+        
+        // MARK: - Overloads
+        describe("Overloads") {
+            
+            it("convenient overloads for setting failure type") {
+                _ = Just(Fail<Int, TestError>(error: .e0)).switchToLatest()
+                _ = Fail<Just<Int>, TestError>(error: .e0).switchToLatest()
+                _ = Just(Just(0)).switchToLatest()
+            }
+        }
     }
 }


### PR DESCRIPTION
Implement [Publisher.assign(to:)](https://developer.apple.com/documentation/combine/publisher/assign(to:)).

Also I forgot pushing `SwitchToLatest` implementations before merging last pr. Added here.