### PR TITLE
Fix SchedulerTypeTime distance(to:)

### DIFF
--- a/Sources/CXFoundation/OperationQueue.swift
+++ b/Sources/CXFoundation/OperationQueue.swift
@@ -54,7 +54,7 @@ extension CXWrappers.OperationQueue: CombineX.Scheduler {
         /// - Returns: The time interval between this time and the provided time.
         public func distance(to other: SchedulerTimeType) -> SchedulerTimeType.Stride {
             
-            return SchedulerTimeType.Stride(floatLiteral: date.timeIntervalSince(other.date))
+            return SchedulerTimeType.Stride(floatLiteral: other.date.timeIntervalSince(date))
         }
     
         /// Returns a operation queue scheduler time calculated by advancing this instance’s time by the given interval.

--- a/Sources/CXFoundation/RunLoop.swift
+++ b/Sources/CXFoundation/RunLoop.swift
@@ -53,7 +53,7 @@ extension CXWrappers.RunLoop: CombineX.Scheduler {
         /// - Parameter other: Another dispatch queue time.
         /// - Returns: The time interval between this time and the provided time.
         public func distance(to other: SchedulerTimeType) -> SchedulerTimeType.Stride {
-            return Stride(floatLiteral: date.timeIntervalSince(other.date))
+            return Stride(floatLiteral: other.date.timeIntervalSince(date))
         }
     
         /// Returns a run loop scheduler time calculated by advancing this instance’s time by the given interval.

--- a/Tests/CXFoundationTests/SchedulerSpec.swift
+++ b/Tests/CXFoundationTests/SchedulerSpec.swift
@@ -35,5 +35,27 @@ class SchedulerSpec: QuickSpec {
             }.to(throwAssertion())
             #endif
         }
+
+        // MARK: 3.1 should compute time intervals correctly.
+        it("should compute time intervals correctly") {
+            typealias RunLoopSchedulerTimeType = CXWrappers.RunLoop.SchedulerTimeType
+
+            let earlyDate = Date(timeIntervalSinceReferenceDate: 69)
+            let lateDate = Date(timeIntervalSinceReferenceDate: 420)
+
+            let earlyRLSTT = RunLoopSchedulerTimeType(earlyDate)
+            let lateRLSTT = RunLoopSchedulerTimeType(lateDate)
+            let rlDistance = earlyRLSTT.distance(to: lateRLSTT)
+            expect(rlDistance) > .seconds(0)
+            expect(lateRLSTT) == earlyRLSTT.advanced(by: rlDistance)
+
+            typealias OperationQueueSchedulerTimeType = CXWrappers.OperationQueue.SchedulerTimeType
+
+            let earlyOQSTT = OperationQueueSchedulerTimeType(earlyDate)
+            let lateOQSTT = OperationQueueSchedulerTimeType(lateDate)
+            let oqDistance = earlyOQSTT.distance(to: lateOQSTT)
+            expect(oqDistance.timeInterval > 0).to(beTrue())
+            expect(lateOQSTT) == earlyOQSTT.advanced(by: oqDistance)
+        }
     }
 }


### PR DESCRIPTION
The new versions of `RunLoop` and `OperationQueue` (copied from the Apple implementations) have incorrect implementations of `SchedulerTimeType::distance(to:)`.

The original Apple implementations rely on `Date::distance(to:)`, which is only available on the 2019 and later systems. So CombineX replaces the use of `Date::distance(to:)` with `Date::timeIntervalSince(_:)`.

The problem is that the calls to `timeIntervalSince` have `date` and `other.date` in the wrong places, so each call to `distance(to:)` returns a `Stride` with a flipped sign.

This pull request contains two commits.

The first commit adds a test case demonstrating the incorrect behavior. The test case succeeds when compiled with Combine and fails when compiled with CombineX. The test case is a little tricky because I was unable to make it compile with Combine using the `RunLoop.CX.SchedulerTimeType` type. I worked around it with type inference, so that it uses `RunLoop.SchedulerTimeType` when compiled with Combine and `RunLoop.CX.SchedulerTimeType` when compiled with CombineX.

The second commit fixes the two implementations of `distance(to:)`.
