### PR TITLE
Publishers.Concatenate should not send zero demand

### DIFF
--- a/Sources/CombineX/Publishers/B/Concatenate.swift
+++ b/Sources/CombineX/Publishers/B/Concatenate.swift
@@ -157,7 +157,9 @@ extension Publishers.Concatenate {
                     let demand = self.demand
                     self.lock.unlock()
                     
-                    subscription.request(demand)
+                    if demand > 0 {
+                        subscription.request(demand)
+                    }
                 }
             case .completed:
                 self.lock.unlock()

--- a/Tests/CombineXTests/Publishers/ConcatenateSpec.swift
+++ b/Tests/CombineXTests/Publishers/ConcatenateSpec.swift
@@ -72,5 +72,11 @@ class ConcatenateSpec: QuickSpec {
                 withExtendedLifetime(sub) {}
             }
         }
+        
+        it("should not send zero demand") {
+            let pub = Just(0).append(Just(1))
+            let sub = pub.subscribeTracingSubscriber(initialDemand: .max(1))
+            expect(sub.eventsWithoutSubscription) == [.value(0)]
+        }
     }
 }


### PR DESCRIPTION
Many publishers such as `Just` and `PassthroughSubject` have `precondition(demand > 0)`.