### PR TITLE
Remove 'isCI' test in Package.swift to resolve CXShim build issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let shimTarget = package.targets.first(where: { $0.name == "CXShim" })!
 shimTarget.dependencies = combineImp.shimTargetDependencies
 shimTarget.swiftSettings.append(contentsOf: combineImp.swiftSettings)
 
-if combineImp == .combine && isCI {
+if combineImp == .combine {
     package.platforms = [.macOS("10.15"), .iOS("13.0"), .tvOS("13.0"), .watchOS("6.0")]
 } else {
     #if compiler(>=5.3)

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,11 @@ enum CombineImplementation {
     
     static var `default`: CombineImplementation {
         #if canImport(Combine)
-        return .combine
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            return .combine
+        } else {
+            return .combineX
+        }
         #else
         return .combineX
         #endif

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -51,7 +51,11 @@ enum CombineImplementation {
     
     static var `default`: CombineImplementation {
         #if canImport(Combine)
-        return .combine
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            return .combine
+        } else {
+            return .combineX
+        }
         #else
         return .combineX
         #endif

--- a/Package@swift-5.2.swift
+++ b/Package@swift-5.2.swift
@@ -136,7 +136,7 @@ shimTarget.swiftSettings.append(contentsOf: combineImp.swiftSettings)
 let testTargets = package.targets.filter { $0.name == "CXTestUtility" || $0.isTest }
 testTargets.forEach { $0.swiftSettings.append(contentsOf: combineImp.swiftSettings) }
 
-if combineImp == .combine && isCI {
+if combineImp == .combine {
     package.platforms = [.macOS("10.15"), .iOS("13.0"), .tvOS("13.0"), .watchOS("6.0")]
 } else {
     #if compiler(>=5.3)


### PR DESCRIPTION
I got a build issue with CXShim when using native Combine with 'Any iOS Device' target selected. This is due to [isCI test yields false in Package.swift](https://github.com/cx-org/CombineX/blob/2116d8826230ae85f34d828389f7f7601290fc01/Package.swift#L130) and thus low platforms that may not have native Combine support are targeted.

<img width="859" alt="截屏2021-05-17 上午10 57 07" src="https://user-images.githubusercontent.com/8158163/118426871-a1f3f400-b6fe-11eb-9fb1-8c81ecd6d731.png">

This pull request tries to fix this issue.
